### PR TITLE
Preselect count and metadata files using environment variables

### DIFF
--- a/EdgeR_colab.py
+++ b/EdgeR_colab.py
@@ -1,11 +1,16 @@
 import subprocess
+import os
 
 import pandas as pd
 import ipywidgets as widgets
 from IPython.display import display
 
-counts_path = widgets.Text(description="Counts CSV:")
-metadata_path = widgets.Text(description="Metadata CSV:")
+counts_path = widgets.Text(
+    description="Counts CSV:", value=os.environ.get("EXP_FILE", "")
+)
+metadata_path = widgets.Text(
+    description="Metadata CSV:", value=os.environ.get("META_FILE", "")
+)
 
 sample_dropdown = widgets.Dropdown(description="Sample column:")
 group_dropdown = widgets.Dropdown(description="Group column:")
@@ -25,6 +30,8 @@ def update_columns(change):
 
 
 metadata_path.observe(update_columns, names="value")
+
+update_columns(None)
 
 run_button = widgets.Button(description="Run EdgeR pipeline")
 output = widgets.Output()


### PR DESCRIPTION
## Summary
- Default counts and metadata file paths now derive from `EXP_FILE` and `META_FILE` environment variables in the Colab widget.
- Preloads metadata columns into sample and group dropdowns on initialization.

## Testing
- `python -m py_compile EdgeR_colab.py`


------
https://chatgpt.com/codex/tasks/task_e_68911873c8d4832cb7959ea5e39d0aca