### PR TITLE
Preselect count and metadata files from notebook variables

### DIFF
--- a/EdgeR_colab.py
+++ b/EdgeR_colab.py
@@ -1,5 +1,6 @@
 import subprocess
 import os
+from os import fspath
 
 import pandas as pd
 import ipywidgets as widgets
@@ -7,8 +8,12 @@ from IPython.display import display
 from IPython import get_ipython
 
 user_ns = get_ipython().user_ns if get_ipython() else {}
-default_counts = str(user_ns.get("EXP_FILE") or os.environ.get("EXP_FILE") or "")
-default_metadata = str(user_ns.get("META_FILE") or os.environ.get("META_FILE") or "")
+
+counts_val = user_ns.get("EXP_FILE") or os.environ.get("EXP_FILE")
+metadata_val = user_ns.get("META_FILE") or os.environ.get("META_FILE")
+
+default_counts = fspath(counts_val) if counts_val else ""
+default_metadata = fspath(metadata_val) if metadata_val else ""
 
 counts_path = widgets.Text(description="Counts CSV:", value=default_counts)
 metadata_path = widgets.Text(description="Metadata CSV:", value=default_metadata)

--- a/EdgeR_colab.py
+++ b/EdgeR_colab.py
@@ -1,11 +1,17 @@
 import subprocess
+import os
 
 import pandas as pd
 import ipywidgets as widgets
 from IPython.display import display
+from IPython import get_ipython
 
-counts_path = widgets.Text(description="Counts CSV:")
-metadata_path = widgets.Text(description="Metadata CSV:")
+user_ns = get_ipython().user_ns if get_ipython() else {}
+default_counts = user_ns.get("EXP_FILE") or os.environ.get("EXP_FILE", "")
+default_metadata = user_ns.get("META_FILE") or os.environ.get("META_FILE", "")
+
+counts_path = widgets.Text(description="Counts CSV:", value=default_counts)
+metadata_path = widgets.Text(description="Metadata CSV:", value=default_metadata)
 
 sample_dropdown = widgets.Dropdown(description="Sample column:")
 group_dropdown = widgets.Dropdown(description="Group column:")
@@ -25,6 +31,8 @@ def update_columns(change):
 
 
 metadata_path.observe(update_columns, names="value")
+
+update_columns(None)
 
 run_button = widgets.Button(description="Run EdgeR pipeline")
 output = widgets.Output()

--- a/EdgeR_colab.py
+++ b/EdgeR_colab.py
@@ -7,8 +7,8 @@ from IPython.display import display
 from IPython import get_ipython
 
 user_ns = get_ipython().user_ns if get_ipython() else {}
-default_counts = user_ns.get("EXP_FILE") or os.environ.get("EXP_FILE", "")
-default_metadata = user_ns.get("META_FILE") or os.environ.get("META_FILE", "")
+default_counts = str(user_ns.get("EXP_FILE") or os.environ.get("EXP_FILE") or "")
+default_metadata = str(user_ns.get("META_FILE") or os.environ.get("META_FILE") or "")
 
 counts_path = widgets.Text(description="Counts CSV:", value=default_counts)
 metadata_path = widgets.Text(description="Metadata CSV:", value=default_metadata)


### PR DESCRIPTION
## Summary
- Prefill counts and metadata file fields using `EXP_FILE` and `META_FILE` from the notebook's namespace, with environment-variable fallbacks
- Populate metadata-dependent dropdowns immediately on load

## Testing
- `python -m py_compile EdgeR_colab.py`


------
https://chatgpt.com/codex/tasks/task_e_68911873c8d4832cb7959ea5e39d0aca