### PR TITLE
Enable optional blocking term in EdgeR pipeline

### DIFF
--- a/EdgeR_colab.py
+++ b/EdgeR_colab.py
@@ -20,6 +20,8 @@ metadata_path = widgets.Text(description="Metadata CSV:", value=default_metadata
 
 sample_dropdown = widgets.Dropdown(description="Sample column:")
 group_dropdown = widgets.Dropdown(description="Group column:")
+donnor_dropdown = widgets.Dropdown(description="Donnor column:")
+use_block = widgets.Checkbox(description="Use blocking term", value=False)
 
 
 def update_columns(change):
@@ -30,14 +32,23 @@ def update_columns(change):
             cols = df.columns.tolist()
             sample_dropdown.options = cols
             group_dropdown.options = cols
+            donnor_dropdown.options = cols
         except Exception as e:
             sample_dropdown.options = []
             group_dropdown.options = []
+            donnor_dropdown.options = []
 
 
 metadata_path.observe(update_columns, names="value")
 
 update_columns(None)
+
+def toggle_donnor(change):
+    donnor_dropdown.layout.display = "block" if change["new"] else "none"
+
+
+use_block.observe(toggle_donnor, names="value")
+toggle_donnor({"new": use_block.value})
 
 run_button = widgets.Button(description="Run EdgeR pipeline")
 output = widgets.Output()
@@ -51,6 +62,7 @@ def run_pipeline(_):
             and metadata_path.value
             and sample_dropdown.value
             and group_dropdown.value
+            and (donnor_dropdown.value if use_block.value else True)
         ):
             print("Please provide all inputs before running the pipeline.")
             return
@@ -63,6 +75,8 @@ def run_pipeline(_):
             sample_dropdown.value,
             group_dropdown.value,
         ]
+        if use_block.value:
+            cmd.append(donnor_dropdown.value)
         result = subprocess.run(cmd, capture_output=True, text=True)
         if result.stdout:
             print(result.stdout)
@@ -72,4 +86,13 @@ def run_pipeline(_):
 
 run_button.on_click(run_pipeline)
 
-display(counts_path, metadata_path, sample_dropdown, group_dropdown, run_button, output)
+display(
+    counts_path,
+    metadata_path,
+    sample_dropdown,
+    group_dropdown,
+    use_block,
+    donnor_dropdown,
+    run_button,
+    output,
+)


### PR DESCRIPTION
## Summary
- Add UI checkbox and dropdown to optionally select a blocking term
- Allow EdgeR pipeline to accept optional donor column and adjust design/contrast

## Testing
- `python -m py_compile EdgeR_colab.py`
- `Rscript -e "parse('EdgeR_pipeline.R')"`


------
https://chatgpt.com/codex/tasks/task_e_689125b6d924832cb4b0c10b3c2db3a7